### PR TITLE
Add two-particle bonds

### DIFF
--- a/CONF.py
+++ b/CONF.py
@@ -1,4 +1,4 @@
-import numpy
+import numpy as np
 import sympy
 
 Np     = 10000      # Number of particles

--- a/fort5_to_hdf5.py
+++ b/fort5_to_hdf5.py
@@ -20,70 +20,12 @@ def is_number(possible_number):
         return False
 
 
-def check_molecule_type(lines):
-    atoms = ['' for _ in range(len(lines))]
-    for i, line in enumerate(lines):
-        split_line = line.split()
-        atoms[i] = split_line[1]
-
-    if len(lines) == 10:
-        expected_atoms_end = ['N', 'P', 'G', 'G',
-                              'C', 'C', 'CE',
-                              'C', 'C', 'CE']
-        expected_atoms = ['N', 'P', 'G', 'G',
-                          'C', 'C', 'C',
-                          'C', 'C', 'C']
-        if atoms == expected_atoms or atoms == expected_atoms_end:
-            return 'DMPC'
-    if len(lines) == 12:
-        expected_atoms_end = ['N', 'P', 'G', 'G',
-                              'C', 'C', 'C', 'CE',
-                              'C', 'C', 'C', 'CE']
-        expected_atoms = ['N', 'P', 'G', 'G',
-                          'C', 'C', 'C', 'C',
-                          'C', 'C', 'C', 'C']
-        if atoms == expected_atoms or atoms == expected_atoms_end:
-            return 'DPPC'
-    elif len(lines) == 14:
-        expected_atoms_end = ['N', 'P', 'G', 'G',
-                              'C', 'C', 'C', 'C', 'CE',
-                              'C', 'C', 'C', 'C', 'CE']
-        expected_atoms = ['N', 'P', 'G', 'G',
-                          'C', 'C', 'C', 'C', 'C',
-                          'C', 'C', 'C', 'C', 'C']
-        if atoms == expected_atoms or atoms == expected_atoms_end:
-            return 'DSPC'
-        expected_atoms_end = ['N', 'P', 'G', 'G',
-                              'C', 'C', 'D', 'C', 'CE',
-                              'C', 'C', 'D', 'C', 'CE']
-        expected_atoms = ['N', 'P', 'G', 'G',
-                          'C', 'C', 'D', 'C', 'C',
-                          'C', 'C', 'D', 'C', 'C']
-        if atoms == expected_atoms or atoms == expected_atoms_end:
-            return 'DOPC'
-
-    elif len(lines) == 5:
-        expected_atoms = ['B' for _ in range(5)]
-        if atoms == expected_atoms:
-            return 'B5'
-
-    elif len(lines) == 1:
-        if atoms[0] == 'B':
-            return 'B'
-        elif atoms[0] == 'W':
-            return 'W'
-        elif atoms[0] == 'WF':
-            return 'WF'
-
-    raise NotImplementedError('Only water, DPPC, DMPC, DOPC, DSPC supported')
-
-
 def fort5_to_hdf5(path, out_path=None, force=False):
     if out_path is None:
-        out_path = os.path.join(os.path.dirname(path), 'converted.gro')
+        out_path = os.path.join(os.path.dirname(path), 'converted.h5')
 
     if os.path.exists(out_path) and not force:
-        raise FileExistsError(f'The target .h5 file, {out_path} already '
+        raise FileExistsError(f'The target .hdf5 file, {out_path} already '
                               f'exists, set force=True (-f flag) to overwrite')
 
     with open(path, 'r') as in_file:
@@ -95,18 +37,16 @@ def fort5_to_hdf5(path, out_path=None, force=False):
     else:
         n_molecules = int(lines[3].split()[0])
 
-    f_hd5 = h5py.File('input.hdf5', 'w')
+    f_hd5 = h5py.File(out_path, 'w')
 
     dset_pos = f_hd5.create_dataset("coordinates", (1, n_atoms, 3),
                                     dtype="Float32")
     dset_vel = f_hd5.create_dataset("velocities", (1, n_atoms, 3),
                                     dtype="Float32")
     dset_types = f_hd5.create_dataset("types", (n_atoms,), dtype="i")
-    dset_molecule_type = f_hd5.create_dataset("molecule_type", (n_atoms,),
-                                              dtype="i")
     dset_molecule_index = f_hd5.create_dataset("molecules", (n_atoms,),
                                                dtype="i")
-    dset_indicies = f_hd5.create_dataset("indicies", (n_atoms,), dtype="i")
+    dset_indices = f_hd5.create_dataset("indices", (n_atoms,), dtype="i")
     dset_names = f_hd5.create_dataset("names", (n_atoms,), dtype="S5")
     dset_bonds = f_hd5.create_dataset("bonds", (n_atoms, 2), dtype="i")
     f_hd5.attrs['box'] = box
@@ -118,10 +58,6 @@ def fort5_to_hdf5(path, out_path=None, force=False):
         atom_indices = [int(s.split()[0]) for s in molecule_lines]
         type_indices = [int(s.split()[2]) for s in molecule_lines]
         names = [s.split()[1] for s in molecule_lines]
-        if len(names) == 1 and names[0] == 'A':
-            molecule_type = 0
-        elif len(names) == 5 and names == ['B' for _ in range(5)]:
-            molecule_type = 1
 
         for i, line in enumerate(molecule_lines):
             atom_index = atom_indices[i] - 1
@@ -130,14 +66,12 @@ def fort5_to_hdf5(path, out_path=None, force=False):
             dset_pos[0, atom_index, :] = np.array(pos_vel[:3])
             dset_vel[0, atom_index, :] = np.array(pos_vel[3:])
             dset_types[atom_index] = type_index
-            dset_molecule_type[atom_index] = molecule_type
             dset_molecule_index[atom_index] = molecule_index
             dset_names[atom_index] = np.string_(names[i])
-            dset_indicies[atom_index] = atom_index
+            dset_indices[atom_index] = atom_index
 
-            bonds = [int(s) for s in line.split()[10:]]
+            bonds = [int(s)-1 for s in line.split()[10:]]
             dset_bonds[atom_index] = bonds[:2]
-        molecule_index += 1
 
     for i, line in enumerate(lines):
         split_line = line.split()
@@ -150,34 +84,7 @@ def fort5_to_hdf5(path, out_path=None, force=False):
                 molecule_start_line + atoms_in_molecule + 1
             ]
             write_to_dataset(molecules_lines, molecule_index)
-            continue
-            """
-            molecule_type = check_molecule_type(molecules_lines)
-            if molecule_type == 'DPPC':
-                NotImplementedError('Fix this')
-                # write_DPPC(out_file, molecules_lines, molecule_index)
-                # molecule_index += 1
-            elif molecule_type == 'DSPC':
-                NotImplementedError('Fix this')
-                # write_DSPC(out_file, molecules_lines, molecule_index)
-                # molecule_index += 1
-            elif molecule_type == 'DOPC':
-                NotImplementedError('Fix this')
-                # write_DOPC(out_file, molecules_lines, molecule_index)
-                # molecule_index += 1
-            elif molecule_type == 'DMPC':
-                NotImplementedError('Fix this')
-                # write_DMPC(out_file, molecules_lines, molecule_index)
-                # molecule_index += 1
-            elif molecule_type == 'W':
-                NotImplementedError('Fix this')
-                # write_water(out_file, molecules_lines, water_index)
-                # water_index += 1
-            else:
-                raise NotImplementedError(
-                    "unrecognized mol type {molecule_type}"
-                )
-            """
+            molecule_index += 1
 
 
 if __name__ == '__main__':

--- a/fort5_to_hdf5.py
+++ b/fort5_to_hdf5.py
@@ -1,0 +1,163 @@
+import numpy as np
+import os
+import argparse
+
+
+def is_int(possible_int):
+    try:
+        _ = int(possible_int)
+        return True
+    except ValueError:
+        return False
+
+
+def is_number(possible_number):
+    try:
+        _ = float(possible_number)
+        return True
+    except ValueError:
+        return False
+
+
+def check_molecule_type(lines):
+    atoms = ['' for _ in range(len(lines))]
+    for i, line in enumerate(lines):
+        split_line = line.split()
+        atoms[i] = split_line[1]
+
+    if len(lines) == 10:
+        expected_atoms_end = ['N', 'P', 'G', 'G',
+                              'C', 'C', 'CE',
+                              'C', 'C', 'CE']
+        expected_atoms = ['N', 'P', 'G', 'G',
+                          'C', 'C', 'C',
+                          'C', 'C', 'C']
+        if atoms == expected_atoms or atoms == expected_atoms_end:
+            return 'DMPC'
+    if len(lines) == 12:
+        expected_atoms_end = ['N', 'P', 'G', 'G',
+                              'C', 'C', 'C', 'CE',
+                              'C', 'C', 'C', 'CE']
+        expected_atoms = ['N', 'P', 'G', 'G',
+                          'C', 'C', 'C', 'C',
+                          'C', 'C', 'C', 'C']
+        if atoms == expected_atoms or atoms == expected_atoms_end:
+            return 'DPPC'
+    elif len(lines) == 14:
+        expected_atoms_end = ['N', 'P', 'G', 'G',
+                              'C', 'C', 'C', 'C', 'CE',
+                              'C', 'C', 'C', 'C', 'CE']
+        expected_atoms = ['N', 'P', 'G', 'G',
+                          'C', 'C', 'C', 'C', 'C',
+                          'C', 'C', 'C', 'C', 'C']
+        if atoms == expected_atoms or atoms == expected_atoms_end:
+            return 'DSPC'
+        expected_atoms_end = ['N', 'P', 'G', 'G',
+                              'C', 'C', 'D', 'C', 'CE',
+                              'C', 'C', 'D', 'C', 'CE']
+        expected_atoms = ['N', 'P', 'G', 'G',
+                          'C', 'C', 'D', 'C', 'C',
+                          'C', 'C', 'D', 'C', 'C']
+        if atoms == expected_atoms or atoms == expected_atoms_end:
+            return 'DOPC'
+
+    elif len(lines) == 1:
+        expected_atoms = ['W']
+        if atoms == expected_atoms:
+            return 'W'
+        expected_atoms_anti_freeze = ['WF']
+        if atoms == expected_atoms_anti_freeze:
+            return 'WF'
+
+    raise NotImplementedError('Only water, DPPC, DMPC, DOPC, DSPC supported')
+
+
+def fort5_to_hdf5(path, out_path=None, force=False):
+    if out_path is None:
+        out_path = os.path.join(os.path.dirname(path), 'converted.gro')
+
+    if os.path.exists(out_path) and not force:
+        raise FileExistsError(f'The target .h5 file, {out_path} already '
+                              f'exists, set force=True (-f flag) to overwrite')
+
+    with open(path, 'r') as in_file:
+        lines = in_file.readlines()
+    box = np.array([float(lines[1].split()[i]) for i in range(3)])
+    n_atoms = int(lines[-1].split()[0])
+    if is_number(lines[2].split()[0]):
+        n_molecules = int(lines[4].split()[0])
+    else:
+        n_molecules = int(lines[3].split()[0])
+
+    f_hd5 = h5py.File('input.hdf5', 'w')
+
+    dset_pos = f_hd5.create_dataset("coordinates",
+                                    (1, n_atoms, 3),
+                                    dtype="Float32")
+    dset_vel = f_hd5.create_dataset("velocities",
+                                    (1, n_atoms, 3),
+                                    dtype="Float32")
+    dset_types = f_hd5.create_dataset("types",
+                                      (n_atoms,),
+                                      dtype="i")
+
+    dset_indicies = f_hd5.create_dataset("indicies", (CONF['Np'],), dtype="i")
+
+
+    with open(out_path, 'w') as out_file:
+        molecule_index = 1
+        water_index = 1
+
+        for i, line in enumerate(lines):
+            split_line = line.split()
+            if i > 4 and len(split_line) == 1 and is_int(split_line[0]):
+                molecule_start_line = i
+                atoms_in_molecule = int(split_line[0])
+
+                molecules_lines = lines[
+                    molecule_start_line+1:
+                    molecule_start_line+atoms_in_molecule+1
+                ]
+                molecule_type = check_molecule_type(molecules_lines)
+                if molecule_type == 'DPPC':
+                    NotImplementedError('Fix this')
+                    # write_DPPC(out_file, molecules_lines, molecule_index)
+                    molecule_index += 1
+                elif molecule_type == 'DSPC':
+                    NotImplementedError('Fix this')
+                    # write_DSPC(out_file, molecules_lines, molecule_index)
+                    molecule_index += 1
+                elif molecule_type == 'DOPC':
+                    NotImplementedError('Fix this')
+                    # write_DOPC(out_file, molecules_lines, molecule_index)
+                    molecule_index += 1
+                elif molecule_type == 'DMPC':
+                    NotImplementedError('Fix this')
+                    # write_DMPC(out_file, molecules_lines, molecule_index)
+                    molecule_index += 1
+                elif molecule_type == 'W':
+                    NotImplementedError('Fix this')
+                    # write_water(out_file, molecules_lines, water_index)
+                    water_index += 1
+                elif molecule_type == 'A':
+
+                else:
+                    raise NotImplementedError(
+                        "unrecognized mol type {molecule_type}"
+                    )
+        out_file.write(f'{box[0]} {box[1]} {box[2]}')
+        print(f'{"DPPC":>20} {"solvent":>20}\n'
+              f'{molecule_index-1:20} {water_index-1:20}')
+
+
+if __name__ == '__main__':
+    description = 'Convert fort.5 OCCAM format to HDF5 format files'
+    parser = argparse.ArgumentParser(description=description)
+    parser.add_argument('file_name', type=str, help='input fort.5 file name')
+    parser.add_argument('--out', type=str, default=None, dest='out_path',
+                        metavar='file name', help='output .h5 file name')
+    parser.add_argument('-f', action='store_true', default=False, dest='force',
+                        help='overwrite existing output file')
+    args = parser.parse_args()
+
+    fort5_to_hdf5(args.file_name, out_path=args.out_path, force=args.force)

--- a/main.py
+++ b/main.py
@@ -61,6 +61,7 @@ if 'molecules' in f_input:
     molecules_flag = True
     molecules = f_input['molecules'][_p_mpi_range]
     indices = f_input['indices'][_p_mpi_range]
+    bonds = f_input['bonds'][p_mpi_range]
 
     if rank == 0:
         mpi_range_start = 0
@@ -93,7 +94,6 @@ f_field=np.zeros((len(r),3))
 f_old=np.copy(f)
 types=f_input['types'][p_mpi_range]
 names = f_input['names'][p_mpi_range]
-bonds = f_input['bonds'][p_mpi_range]
 f_input.close()
 
 

--- a/make_example_fort5.py
+++ b/make_example_fort5.py
@@ -18,7 +18,9 @@ with open('fort.5', 'w') as out_file:
     out_file.write(f'n_molecules:\n\t{n_molecules}\n')
 
     for p in range(n_polymers):
-        out_file.write(f'molecule_index:\t{p + 1}\n\t\t{n_atoms_per_polymer}\n')
+        out_file.write(
+            f'molecule_index:\t{p + 1}\n\t\t{n_atoms_per_polymer}\n'
+        )
         position_xy = 2.0 + p
 
         z_start = np.random.uniform(low=0.0, high=7.0, size=1)[0]
@@ -36,7 +38,7 @@ with open('fort.5', 'w') as out_file:
                 bonds = 2
                 bonds_indices = (atom_index - 1, atom_index + 1, 0, 0, 0, 0)
 
-            out_file.write(f'{atom_index:4}\t{atom_type_name:4}\t{atom_index:4}\t{bonds:4}')  # noqa: E501
+            out_file.write(f'{atom_index:4}\t{atom_type_name:4}\t{atom_type:4}\t{bonds:4}')  # noqa: E501
             out_file.write(f'\t\t{x:.3f}\t{y:.3f}\t{z:.3f}')
             out_file.write(f'\t{0.0:.3f}\t{0.0:.3f}\t{0.0:.3f}\t')
             for b in bonds_indices:
@@ -52,7 +54,7 @@ with open('fort.5', 'w') as out_file:
         bonds = 0
         bonds_indices = (0, 0, 0, 0, 0, 0)
 
-        out_file.write(f'{atom_index:4}\t{atom_type_name:4}\t{atom_index:4}\t{bonds:4}')  # noqa: E501
+        out_file.write(f'{atom_index:4}\t{atom_type_name:4}\t{atom_type:4}\t{bonds:4}')  # noqa: E501
         out_file.write(f'\t\t{x:.3f}\t{y:.3f}\t{z:.3f}')
         out_file.write(f'\t{0.0:.3f}\t{0.0:.3f}\t{0.0:.3f}\t')
         for b in bonds_indices:

--- a/make_example_fort5.py
+++ b/make_example_fort5.py
@@ -61,7 +61,7 @@ def write_fort5(box_size,
 
             for a in range(n_atoms_per_polymer):
                 R = Rotation.random()
-                displacement = np.array([1, 0, 0])
+                displacement = np.array([0.25, 0, 0])
                 displacement = R.apply(displacement)
                 position = position + displacement
                 position = np.squeeze(position)
@@ -69,7 +69,7 @@ def write_fort5(box_size,
                 for dim in range(len(position)):
                     while position[dim] > box_size[dim]:
                         position[dim] -= box_size[dim]
-                    while position[dim] < box_size[dim]:
+                    while position[dim] < 0.0:
                         position[dim] += box_size[dim]
 
                 atom_type_name = polymer_topology[a]
@@ -83,7 +83,7 @@ def write_fort5(box_size,
                         bonds_adjusted[i] = b + p * n_atoms_per_polymer
 
                 out_file.write(f'{atom_index:4}\t{atom_type_name:4}\t{atom_type:4}\t{num_bonds:4}')  # noqa: E501
-                out_file.write(f'\t\t{position[0]:.3f}\t{position[1]:.3f}\t{position[2]:.3f}')  # noqa: E501
+                out_file.write(f'\t\t{position[0]:.16f}\t{position[1]:.16f}\t{position[2]:.16f}')  # noqa: E501
                 out_file.write(f'\t{0.0:.3f}\t{0.0:.3f}\t{0.0:.3f}\t')
                 for b in bonds_adjusted:
                     out_file.write(f'\t{b:4}')
@@ -117,9 +117,9 @@ if __name__ == '__main__':
     parser.add_argument('--box', type=int, nargs=3,
                         help='simulation box length')
     parser.add_argument('--n-molecules', type=int, dest='n_molecules',
-                        help='number of molecules')
+                        help='number of molecules', default=0)
     parser.add_argument('--n-solvent', type=int, dest='n_solvent',
-                        help='number of solvent atoms')
+                        help='number of solvent atoms', default=0)
     parser.add_argument('--system', type=str,
                         help='what kind of system to generate',
                         choices=['diblock-copolymer'])

--- a/make_example_fort5.py
+++ b/make_example_fort5.py
@@ -1,42 +1,102 @@
 import numpy as np
+import argparse
+import os
+from scipy.spatial.transform import Rotation
 
 
-box_size = (10, 10, 10)
-n_polymers = 5
-n_atoms_per_polymer = 5
-n_solvent = 500
-n_molecules = n_polymers + n_solvent
-n_atoms = n_polymers * n_atoms_per_polymer + n_solvent
+def write_fort5(box_size,
+                n_polymers,
+                n_solvent,
+                polymer_topology=None,
+                bonds=None,
+                out_path=None,
+                force=False):
+    if n_polymers > 0:
+        if polymer_topology is None and bonds is None:
+            raise ValueError('polymer_topology and bonds must be specified '
+                             'with n_polymers > 0')
+        elif polymer_topology is None:
+            raise ValueError(
+                'polymer_topology must be specified with n_polymers > 0'
+            )
+        elif bonds is None:
+            raise ValueError('bonds must be specified with n_polymers > 0')
 
+    n_atoms_per_polymer = len(polymer_topology)
+    n_molecules = n_polymers + n_solvent
+    n_atoms = n_molecules * n_atoms_per_polymer + n_solvent
 
-with open('fort.5', 'w') as out_file:
-    out_file.write('box:\n\t')
-    for b in box_size:
-        out_file.write(f'{b:.10f}\t')
-    out_file.write('\n\t')
-    out_file.write(f'{0.0:.10f}\n')
-    out_file.write(f'n_molecules:\n\t{n_molecules}\n')
+    if out_path is None:
+        out_path = 'fort.5'
+    if os.path.exists(out_path):
+        if not force:
+            raise FileExistsError(f'The file {out_path} already exists. Use '
+                                  f'the -f flag to force overwrite.')
 
-    for p in range(n_polymers):
-        out_file.write(
-            f'molecule_index:\t{p + 1}\n\t\t{n_atoms_per_polymer}\n'
-        )
-        position_xy = 2.0 + p
+    rng = np.random.default_rng()
 
-        z_start = np.random.uniform(low=0.0, high=7.0, size=1)[0]
-        for a in range(n_atoms_per_polymer):
-            x, y = position_xy, position_xy
-            z = z_start + 0.5 * a
-            atom_type_name = 'B'
-            atom_type = 2
-            atom_index = p * n_atoms_per_polymer + a + 1
-            if (a == 0) or (a == n_atoms_per_polymer - 1):
-                bonds = 1
-                bonded_index = atom_index + 1 if a == 0 else atom_index - 1
-                bonds_indices = (bonded_index, 0, 0, 0, 0, 0)
-            else:
-                bonds = 2
-                bonds_indices = (atom_index - 1, atom_index + 1, 0, 0, 0, 0)
+    atom_types = {}
+    ind = 1
+    for a in polymer_topology:
+        if a not in atom_types:
+            atom_types[a] = ind
+            ind += 1
+    atom_types['W'] = ind
+
+    with open(out_path, 'w') as out_file:
+        out_file.write('box:\n\t')
+        for b in box_size:
+            out_file.write(f'{b:.10f}\t')
+        out_file.write('\n\t')
+        out_file.write(f'{0.0:.10f}\n')
+        out_file.write(f'n_molecules:\n\t{n_molecules}\n')
+
+        for p in range(n_polymers):
+            out_file.write(
+                f'molecule_index:\t{p + 1}\n\t\t{n_atoms_per_polymer}\n'
+            )
+            position = np.array(
+                [rng.uniform(high=box_size[i], size=1) for i in range(3)]
+            ).T
+
+            for a in range(n_atoms_per_polymer):
+                R = Rotation.random()
+                displacement = np.array([1, 0, 0])
+                displacement = R.apply(displacement)
+                position = position + displacement
+                position = np.squeeze(position)
+
+                for dim in range(len(position)):
+                    while position[dim] > box_size[dim]:
+                        position[dim] -= box_size[dim]
+                    while position[dim] < box_size[dim]:
+                        position[dim] += box_size[dim]
+
+                atom_type_name = polymer_topology[a]
+                atom_type = atom_types[atom_type_name]
+                atom_index = p * n_atoms_per_polymer + a + 1
+
+                bonds_adjusted = [0 for _ in range(6)]
+                num_bonds = len([1 for i in bonds[a] if i != -1])
+                for i, b in enumerate(bonds[a]):
+                    if b != -1:
+                        bonds_adjusted[i] = b + p * n_atoms_per_polymer
+
+                out_file.write(f'{atom_index:4}\t{atom_type_name:4}\t{atom_type:4}\t{num_bonds:4}')  # noqa: E501
+                out_file.write(f'\t\t{position[0]:.3f}\t{position[1]:.3f}\t{position[2]:.3f}')  # noqa: E501
+                out_file.write(f'\t{0.0:.3f}\t{0.0:.3f}\t{0.0:.3f}\t')
+                for b in bonds_adjusted:
+                    out_file.write(f'\t{b:4}')
+                out_file.write('\n')
+
+        for s in range(n_solvent):
+            out_file.write(f'molecule_index:\t{n_polymers + s + 1}\n\t{1}\n')
+            x, y, z = np.random.uniform(low=0.0, high=10.0, size=3)
+            atom_type_name = 'W'
+            atom_type = atom_types[atom_type_name]
+            atom_index = n_polymers * n_atoms_per_polymer + s + 1
+            bonds = 0
+            bonds_indices = (0, 0, 0, 0, 0, 0)
 
             out_file.write(f'{atom_index:4}\t{atom_type_name:4}\t{atom_type:4}\t{bonds:4}')  # noqa: E501
             out_file.write(f'\t\t{x:.3f}\t{y:.3f}\t{z:.3f}')
@@ -45,22 +105,40 @@ with open('fort.5', 'w') as out_file:
                 out_file.write(f'\t{b:4}')
             out_file.write('\n')
 
-    for s in range(n_solvent):
-        out_file.write(f'molecule_index:\t{n_polymers + s + 1}\n\t{1}\n')
-        x, y, z = np.random.uniform(low=0.0, high=10.0, size=3)
-        atom_type_name = 'A'
-        atom_type = 1
-        atom_index = n_polymers * n_atoms_per_polymer + s + 1
-        bonds = 0
-        bonds_indices = (0, 0, 0, 0, 0, 0)
+    if n_atoms < 1000:
+        with open(out_path, 'r') as in_file:
+            for i, line in enumerate(in_file):
+                print(line.strip())
 
-        out_file.write(f'{atom_index:4}\t{atom_type_name:4}\t{atom_type:4}\t{bonds:4}')  # noqa: E501
-        out_file.write(f'\t\t{x:.3f}\t{y:.3f}\t{z:.3f}')
-        out_file.write(f'\t{0.0:.3f}\t{0.0:.3f}\t{0.0:.3f}\t')
-        for b in bonds_indices:
-            out_file.write(f'\t{b:4}')
-        out_file.write('\n')
 
-with open('fort.5', 'r') as in_file:
-    for i, line in enumerate(in_file):
-        print(line.strip())
+if __name__ == '__main__':
+    description = 'Create example fort.5 files'
+    parser = argparse.ArgumentParser(description=description)
+    parser.add_argument('--box', type=int, nargs=3,
+                        help='simulation box length')
+    parser.add_argument('--n-molecules', type=int, dest='n_molecules',
+                        help='number of molecules')
+    parser.add_argument('--n-solvent', type=int, dest='n_solvent',
+                        help='number of solvent atoms')
+    parser.add_argument('--system', type=str,
+                        help='what kind of system to generate',
+                        choices=['diblock-copolymer'])
+    parser.add_argument('--out', type=str, default=None, dest='out_path',
+                        metavar='file name', help='output fort.5 file name')
+    parser.add_argument('-f', action='store_true', dest='force',
+                        help='overwrite existing output file')
+    args = parser.parse_args()
+
+    if args.n_molecules > 0 and args.system == 'diblock-copolymer':
+        polymer_topology = ['A' for _ in range(10)] + ['B' for _ in range(10)]
+        bonds = np.empty(shape=(20, 2), dtype=int)
+        bonds[0, :] = np.array([2, -1])
+        bonds[-1, :] = np.array([19, -1])
+        bonds[1:-1, 0] = np.arange(1, 19, 1, dtype=int)
+        bonds[1:-1, 1] = np.arange(3, 21, 1, dtype=int)
+    else:
+        raise NotImplementedError('only -diblock-copolymer supported')
+
+    write_fort5(args.box, args.n_molecules, args.n_solvent,
+                polymer_topology=polymer_topology, bonds=bonds,
+                out_path=args.out_path, force=args.force)

--- a/make_example_fort5.py
+++ b/make_example_fort5.py
@@ -1,0 +1,64 @@
+import numpy as np
+
+
+box_size = (10, 10, 10)
+n_polymers = 5
+n_atoms_per_polymer = 5
+n_solvent = 500
+n_molecules = n_polymers + n_solvent
+n_atoms = n_polymers * n_atoms_per_polymer + n_solvent
+
+
+with open('fort.5', 'w') as out_file:
+    out_file.write('box:\n\t')
+    for b in box_size:
+        out_file.write(f'{b:.10f}\t')
+    out_file.write('\n\t')
+    out_file.write(f'{0.0:.10f}\n')
+    out_file.write(f'n_molecules:\n\t{n_molecules}\n')
+
+    for p in range(n_polymers):
+        out_file.write(f'molecule_index:\t{p + 1}\n\t\t{n_atoms_per_polymer}\n')
+        position_xy = 2.0 + p
+
+        z_start = np.random.uniform(low=0.0, high=7.0, size=1)[0]
+        for a in range(n_atoms_per_polymer):
+            x, y = position_xy, position_xy
+            z = z_start + 0.5 * a
+            atom_type_name = 'B'
+            atom_type = 2
+            atom_index = p * n_atoms_per_polymer + a + 1
+            if (a == 0) or (a == n_atoms_per_polymer - 1):
+                bonds = 1
+                bonded_index = atom_index + 1 if a == 0 else atom_index - 1
+                bonds_indices = (bonded_index, 0, 0, 0, 0, 0)
+            else:
+                bonds = 2
+                bonds_indices = (atom_index - 1, atom_index + 1, 0, 0, 0, 0)
+
+            out_file.write(f'{atom_index:4}\t{atom_type_name:4}\t{atom_index:4}\t{bonds:4}')  # noqa: E501
+            out_file.write(f'\t\t{x:.3f}\t{y:.3f}\t{z:.3f}')
+            out_file.write(f'\t{0.0:.3f}\t{0.0:.3f}\t{0.0:.3f}\t')
+            for b in bonds_indices:
+                out_file.write(f'\t{b:4}')
+            out_file.write('\n')
+
+    for s in range(n_solvent):
+        out_file.write(f'molecule_index:\t{n_polymers + s + 1}\n\t{1}\n')
+        x, y, z = np.random.uniform(low=0.0, high=10.0, size=3)
+        atom_type_name = 'A'
+        atom_type = 1
+        atom_index = n_polymers * n_atoms_per_polymer + s + 1
+        bonds = 0
+        bonds_indices = (0, 0, 0, 0, 0, 0)
+
+        out_file.write(f'{atom_index:4}\t{atom_type_name:4}\t{atom_index:4}\t{bonds:4}')  # noqa: E501
+        out_file.write(f'\t\t{x:.3f}\t{y:.3f}\t{z:.3f}')
+        out_file.write(f'\t{0.0:.3f}\t{0.0:.3f}\t{0.0:.3f}\t')
+        for b in bonds_indices:
+            out_file.write(f'\t{b:4}')
+        out_file.write('\n')
+
+with open('fort.5', 'r') as in_file:
+    for i, line in enumerate(in_file):
+        print(line.strip())

--- a/make_input.py
+++ b/make_input.py
@@ -43,10 +43,10 @@ parts=1000
 n=int(CONF['Np']/parts)
 #print(n,CONF['Np'])
 for i in range(parts-1):
-    indices.append(range(i*n,(i+1)*n))
+    indices.append(list(range(i*n,(i+1)*n)))
 
 if not(n*i==CONF['Np']):
-    indices.append(range((i+1)*n,CONF['Np']))
+    indices.append(list(range((i+1)*n,CONF['Np'])))
 
 
 def cube(r):

--- a/make_input.py
+++ b/make_input.py
@@ -5,7 +5,7 @@ import json
 
 CONF = {}
 exec(open(sys.argv[1]).read(), CONF)
-np.random.seed(0) 
+np.random.seed(0)
 # Initialization of simulation variables
 kb=2.479/298
 if 'T0' in CONF:
@@ -29,7 +29,7 @@ f_hd5      = h5py.File('input.hdf5', 'w')
 dset_pos      = f_hd5.create_dataset("coordinates", (1,CONF['Np'],3), dtype="Float32")
 dset_vel      = f_hd5.create_dataset("velocities",  (1,CONF['Np'],3), dtype="Float32")
 dset_types    = f_hd5.create_dataset("types",       (CONF['Np'],), dtype="i")
-dset_indicies = f_hd5.create_dataset("indicies",    (CONF['Np'],), dtype="i")
+dset_indices = f_hd5.create_dataset("indices",    (CONF['Np'],), dtype="i")
 
 dt =  h5py.string_dtype(encoding='ascii')
 dset_names = f_hd5.create_dataset("names",  (CONF['Np'],), dtype="S10")
@@ -38,32 +38,32 @@ dset_mass = f_hd5.create_dataset("mass",  (CONF['Np'],), dtype="Float32")
 dset_pos.attrs['units']="nanometers"
 dset_pos.attrs['units']="nanometers/picoseconds"
 
-indicies=[]
+indices=[]
 parts=1000
 n=int(CONF['Np']/parts)
 #print(n,CONF['Np'])
 for i in range(parts-1):
-    indicies.append(range(i*n,(i+1)*n))
- 
+    indices.append(range(i*n,(i+1)*n))
+
 if not(n*i==CONF['Np']):
-    indicies.append(range((i+1)*n,CONF['Np']))
+    indices.append(range((i+1)*n,CONF['Np']))
 
 
 def cube(r):
     radius=np.max(np.abs(r-CONF['L'][None,:]*0.5),axis=1)
     ind=np.argsort(radius)[::-1]
     r=r.copy()[ind,:]
-    
+
     return r
 
 
 def GEN_START_UNIFORM():
-    
+
     n=int(np.ceil(CONF['Np']**(1./3.)))
     print(n)
     l=CONF['L'][0]/n
     x=np.linspace(0.5*l,(n-0.5)*l,n)
-    
+
     j=0
     for ix in range(n):
         for iy in range(n):
@@ -88,17 +88,17 @@ def GEN_RANDOM(dset):
     #     dset[0,i=CONF['L']*np.random.random((nrange[i+1]-nrange[i],3))
 
 #    for i in range(CONF['Np']):
-    for ind in indicies:
+    for ind in indices:
         dset[0,ind,:]=CONF['L']*np.random.random((len(ind),3))
-    
+
 def GEN_START_VEL(dset):
     #NORMAL DISTRIBUTED PARTICLES FIRST FRAME
     std  = np.sqrt(CONF['kbT_start']/CONF['mass'])
     dset[0,:,:] = np.random.normal(loc=0, scale=std,size=(CONF['Np'],3))
-    
+
     dset[0,:,:] = dset[0,:,:]-np.mean(dset[0,:,:], axis=0)
     fac= np.sqrt((3*CONF['Np']*CONF['kbT_start']/2.)/(0.5*CONF['mass']*np.sum(dset[0,:,:]**2)))
-    
+
     dset[0,:,:]=dset[0,:,:]*fac
 
 
@@ -116,22 +116,22 @@ if 'T_start' in CONF:
 #for i in range(CONF['Np']):
 
 
-for ind in indicies:
+for ind in indices:
     dset_types[ind]=0
     dset_names[ind]=np.string_("A")
     dset_mass[ind]=CONF['mass']
-    dset_indicies[ind]=np.array(ind)
+    dset_indices[ind]=np.array(ind)
 
- 
+
 if 'chi' in CONF and 'NB' in CONF:
    #" for i in range(CONF['Np']-CONF['NB'],CONF['Np']):
-    #indicies2=np.array(range(CONF['Np']-CONF['NB']))
-    for ind in np.split(indicies,100):
+    #indices2=np.array(range(CONF['Np']-CONF['NB']))
+    for ind in np.split(indices,100):
         ind2=ind[ind>CONF['Np']-CONF['NB']]
         if(len(ind2)>0):
             dset_types[ind2]=1
             dset_names[ind2]=np.string_("B")
-      
+
 f_hd5.close()
 
 
@@ -141,6 +141,4 @@ f_hd5.close()
 # print(f_hd5.get('types')[:])
 # print(f_hd5.get('names')[:])
 # print(f_hd5.get('mass')[:])
-# print(f_hd5.get('indicies')[:])
-
-
+# print(f_hd5.get('indices')[:])


### PR DESCRIPTION
Also adds `make_example_fort5.py` which may be used to set up example polymer systems for test runs along with `fort5_to_hdf5.py` to convert `fort.5` to hPF input.

All the changes should (hopefully) not break any existing functionality, however, note the rename of what used to be called `f` to `f_field`, as `f` now represents the sum of all forces, not just the hPF force. 